### PR TITLE
Add gitattributes to generate useful statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.kicad_prl linguist-language=Kicad-Layout
+*.kicad_pro linguist-language=Kicad-Layout
+*.kicad_pcb linguist-detectable
+*.kicad_prl linguist-detectable
+*.kicad_pro linguist-detectable
+*.kicad_sch linguist-detectable


### PR DESCRIPTION
Per https://github.com/github/linguist/blob/master/docs/overrides.md kicad files are not included in statistics by default.

Enabling them produces the following:

![screenshot_2023-03-25_at_09 57 05_480](https://user-images.githubusercontent.com/3986/227710302-1cc81f65-808b-45eb-9893-b2f03af1e50e.png)

I must admit the types are guesswork: I don't know if `_prl` and `_pro` are best classified as layout files or what.